### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   build:
     name: Build Docusaurus
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/kinoko2k/kinokoserver-documents/security/code-scanning/3](https://github.com/kinoko2k/kinokoserver-documents/security/code-scanning/3)

To fix the problem, explicitly set the permissions for the `build` job in `.github/workflows/deploy.yml`, restricting the `GITHUB_TOKEN` to read-only access. This is done by adding a `permissions:` block with `contents: read` under the `build` job. This ensures the token cannot be used to modify repository contents or other sensitive resources, while still allowing the job to perform actions such as checking out the code. The block should be placed at the same indentation level as `name`, `runs-on`, and `steps` within the `build` job (i.e., after `name` and before `runs-on`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
